### PR TITLE
Add `load` method to `DbExperimentDataV1` and `DbAnalysisResultV1`

### DIFF
--- a/qiskit_experiments/database_service/db_analysis_result.py
+++ b/qiskit_experiments/database_service/db_analysis_result.py
@@ -133,55 +133,36 @@ class DbAnalysisResultV1(DbAnalysisResult):
                 pass
         self._extra_data = kwargs
 
-    def serialize_data(self) -> str:
-        """Serialize result data into JSON string.
-
-        Returns:
-            Serialized JSON string.
-        """
-        return json.dumps(self._result_data, cls=self._json_encoder)
-
     @classmethod
-    def deserialize_data(cls, data: str) -> Dict:
-        """Deserialize experiment from JSON string.
+    def load(cls, result_id: str, service: DatabaseServiceV1) -> "DbAnalysisResultV1":
+        """Load a saved analysis result from a database service.
 
         Args:
-            data: Data to be deserialized.
+            result_id: Analysis result ID.
+            service: the database service.
 
         Returns:
-            Deserialized data.
+            The loaded analysis result.
         """
-        return json.loads(data, cls=cls._json_decoder)
-
-    @classmethod
-    def from_data(
-        cls,
-        result_data: Dict,
-        result_type: str,
-        device_components: List[Union[DeviceComponent, str]],
-        experiment_id: str,
-        **kwargs,
-    ) -> "DbAnalysisResultV1":
-        """Reconstruct the analysis result from input data.
-
-        Args:
-            result_data: Analysis result data.
-            result_type: Analysis result type.
-            device_components: Target device components this analysis is for.
-            experiment_id: ID of the experiment.
-            **kwargs: Additional analysis result attributes.
-
-        Returns:
-            Reconstructed analysis result.
-        """
+        # Load data from the service
+        data = service.analysis_result(result_id)
+        result_data = data["result_data"]
+        # Parse serialized data
         if result_data:
-            result_data = cls.deserialize_data(json.dumps(result_data))
-        return cls(
-            result_data=result_data,
-            result_type=result_type,
-            device_components=device_components,
-            experiment_id=experiment_id,
-            **kwargs,
+            result_data = json.loads(
+                json.dumps(result_data, cls=cls._json_encoder), cls=cls._json_decoder
+            )
+        # Initialize the result object
+        return DbAnalysisResultV1(
+            result_data,
+            result_type=data["result_type"],
+            device_components=data["device_components"],
+            experiment_id=data["experiment_id"],
+            result_id=data["result_id"],
+            quality=data["quality"],
+            verified=data["verified"],
+            tags=data["tags"],
+            service=data["service"],
         )
 
     def save(self) -> None:
@@ -196,7 +177,7 @@ class DbAnalysisResultV1(DbAnalysisResult):
             )
             return
 
-        _result_data = json.loads(self.serialize_data())
+        _result_data = json.loads(json.dumps(self._result_data, cls=self._json_encoder))
         _result_data["_source"] = self._source
 
         new_data = {

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -329,6 +329,20 @@ class DbExperimentDataV1(DbExperimentData):
         """
         self._data.append(data)
 
+    def _retrieve_data(self):
+        """Retrieve job data if missing experiment data."""
+        # Get job results if missing experiment data.
+        if (not self._data) and self._provider:
+            with self._jobs.lock:
+                for jid in self._jobs:
+                    if self._jobs[jid] is None:
+                        try:
+                            self._jobs[jid] = self._provider.retrieve_job(jid)
+                        except Exception:  # pylint: disable=broad-except
+                            pass
+                    if self._jobs[jid] is not None:
+                        self._add_result_data(self._jobs[jid].result())
+
     def data(self, index: Optional[Union[int, slice, str]] = None) -> Union[Dict, List[Dict]]:
         """Return the experiment data at the specified index.
 
@@ -347,18 +361,7 @@ class DbExperimentDataV1(DbExperimentData):
         Raises:
             TypeError: If the input `index` has an invalid type.
         """
-        # Get job results if missing experiment data.
-        if (not self._data) and self._provider:
-            with self._jobs.lock:
-                for jid in self._jobs:
-                    if self._jobs[jid] is None:
-                        try:
-                            self._jobs[jid] = self._provider.retrieve_job(jid)
-                        except Exception:  # pylint: disable=broad-except
-                            pass
-                    if self._jobs[jid] is not None:
-                        self._add_result_data(self._jobs[jid].result())
-
+        self._retrieve_data()
         if index is None:
             return self._data.copy()
         if isinstance(index, (int, slice)):
@@ -585,6 +588,21 @@ class DbExperimentDataV1(DbExperimentData):
 
         return result_key
 
+    def _retrieve_analysis_results(self, refresh: bool = False):
+        """Retrieve service analysis results.
+
+        Args:
+            refresh: Retrieve the latest analysis results from the server, if
+                an experiment service is available.
+        """
+        # Get job results if missing experiment data.
+        if self.service and (not self._analysis_results or refresh):
+            retrieved_results = self.service.analysis_results(
+                experiment_id=self.experiment_id, limit=None
+            )
+            for result in retrieved_results:
+                self._analysis_results[result["result_id"]] = DbAnalysisResult.from_data(**result)
+
     def analysis_results(
         self, index: Optional[Union[int, slice, str]] = None, refresh: bool = False
     ) -> Union[DbAnalysisResult, List[DbAnalysisResult]]:
@@ -608,13 +626,7 @@ class DbExperimentDataV1(DbExperimentData):
             TypeError: If the input `index` has an invalid type.
             DbExperimentEntryNotFound: If the entry cannot be found.
         """
-        if self.service and (not self._analysis_results or refresh):
-            retrieved_results = self.service.analysis_results(
-                experiment_id=self.experiment_id, limit=None
-            )
-            for result in retrieved_results:
-                self._analysis_results[result["result_id"]] = DbAnalysisResult.from_data(**result)
-
+        self._retrieve_analysis_results(refresh=refresh)
         if index is None:
             return self._analysis_results.values()
         if isinstance(index, (int, slice)):
@@ -646,7 +658,7 @@ class DbExperimentDataV1(DbExperimentData):
             LOG.warning("Experiment cannot be saved because backend is missing.")
             return
 
-        metadata = json.loads(self.serialize_metadata())
+        metadata = json.loads(json.dumps(self._metadata, cls=self._json_encoder))
         metadata["_source"] = self._source
 
         update_data = {
@@ -710,53 +722,45 @@ class DbExperimentDataV1(DbExperimentData):
                 self._service.delete_figure(experiment_id=self.experiment_id, figure_name=name)
             self._deleted_figures.remove(name)
 
-    def serialize_metadata(self) -> str:
-        """Serialize experiment metadata into a JSON string.
-
-        Returns:
-            Serialized JSON string.
-        """
-        return json.dumps(self._metadata, cls=self._json_encoder)
-
     @classmethod
-    def deserialize_metadata(cls, data: str) -> Any:
-        """Deserialize experiment metadata from a JSON string.
+    def load(cls, experiment_id: str, service: DatabaseServiceV1) -> "DbExperimentDataV1":
+        """Load a saved experiment data from a database service.
 
         Args:
-            data: Data to be deserialized.
+            experiment_id: Experiment ID.
+            service: the database service.
 
         Returns:
-            Deserialized data.
+            The loaded experiment data.
         """
-        return json.loads(data, cls=cls._json_decoder)
+        # Load data from the service
+        data = service.aexperiment(experiment_id)
 
-    @classmethod
-    def from_data(
-        cls,
-        experiment_type: str,
-        experiment_id: str,
-        metadata: Optional[Dict] = None,
-        **kwargs,
-    ) -> "DbExperimentDataV1":
-        """Reconstruct a DbExperimentDataV1 using the input data.
-
-        Args:
-            experiment_type: Experiment type.
-            experiment_id: Experiment ID. One will be generated if not supplied.
-            metadata: Additional experiment metadata.
-            **kwargs: Additional experiment attributes.
-
-        Returns:
-            An DbExperimentDataV1 instance.
-        """
+        # Parse serialized metadata
+        metadata = data["metadata"]
         if metadata:
-            metadata = cls.deserialize_metadata(json.dumps(metadata))
-        return cls(
-            experiment_type=experiment_type,
-            experiment_id=experiment_id,
+            metadata = json.loads(json.dumps(metadata), cls=cls._json_decoder)
+
+        # Initialize container
+        # NOTE: not sure how to parse extra_args from service data
+        expdata = DbExperimentDataV1(
+            experiment_type=data["experiment_data"],
+            backend=data["backend"],
+            experiment_id=data["experiment_id"],
+            tags=data["tags"],
+            job_ids=data["job_ids"],
+            share_level=data["share_level"],
             metadata=metadata,
-            **kwargs,
+            figure_names=data["figure_names"],
+            notes=data["notes"],
         )
+
+        # Retrieve analysis results
+        # Maybe this isn't necessary but the repr of the class should
+        # be updated to show correct number of results including remote ones
+        expdata._retrieve_analysis_results()
+
+        return expdata
 
     def cancel_jobs(self) -> None:
         """Cancel any running jobs."""


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

@jyu00 

This method parses the dicts currently returned by the IBMQ service to allow loading saved experiment data and analysis results.

### Details and comments

There are still a couple of issues: when loading an DbExperimentDataV1 the repr doesn't show the correct number of `data` and `analysis_results` stored remotely. I added a call to retreive the analysis results, but this might not be necessary if the repr is updated. I tried adding a call to retrieve result data but got errors so I think some other issue might be involved here.